### PR TITLE
Remove <unistd.h> from wolk_connector.c

### DIFF
--- a/sources/wolk_connector.c
+++ b/sources/wolk_connector.c
@@ -27,7 +27,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
-#include <unistd.h>
 
 #define TIMEOUT_STEP 100000
 


### PR DESCRIPTION
Most bare metal devices doesn't have support for POSIX API, so unistd is
not needed by default.