### PR TITLE
Replace non portable math.h:ceil with custom implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/out/bin")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/out/lib")
 
 add_library(${LIBRARY_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
-target_link_libraries(${LIBRARY_NAME} paho-embed-mqtt3c m)
+target_link_libraries(${LIBRARY_NAME} paho-embed-mqtt3c)
 
 # Format code
 add_custom_target(format

--- a/sources/firmware_update.c
+++ b/sources/firmware_update.c
@@ -22,7 +22,6 @@
 #include "wolk_connector.h"
 #include "wolk_utils.h"
 
-#include <math.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -385,7 +384,7 @@ static void _handle_file_upload(firmware_update_t* firmware_update, firmware_upd
         firmware_update->next_chunk_index = 0;
 
         firmware_update->expected_number_of_chunks =
-            (size_t)ceil((double)firmware_update_command_get_file_size(command) / firmware_update->chunk_size);
+            (size_t)WOLK_CEIL((double)firmware_update_command_get_file_size(command) / firmware_update->chunk_size);
         firmware_update->retry_count = 0;
 
         _listener_on_status(firmware_update, firmware_update_status_ok(FIRMWARE_UPDATE_STATE_FILE_TRANSFER));
@@ -577,7 +576,8 @@ static bool _is_firmware_file_valid(firmware_update_t* firmware_update)
     sha256_context sha256_ctx;
     sha256_init(&sha256_ctx);
 
-    for (size_t i = 0; i < (size_t)ceil((double)firmware_update->file_size / FIRMWARE_VERIFICATION_CHUNK_SIZE); ++i) {
+    for (size_t i = 0; i < (size_t)WOLK_CEIL((double)firmware_update->file_size / FIRMWARE_VERIFICATION_CHUNK_SIZE);
+         ++i) {
         uint8_t read_data[FIRMWARE_VERIFICATION_CHUNK_SIZE];
         const size_t read_data_size = _read_chunk(firmware_update, i, read_data, WOLK_ARRAY_LENGTH(read_data));
         sha256_hash(&sha256_ctx, read_data, read_data_size);

--- a/sources/firmware_update_packet.c
+++ b/sources/firmware_update_packet.c
@@ -63,6 +63,8 @@ uint8_t* firmware_update_packet_get_previous_packet_hash(uint8_t* packet, size_t
     WOLK_ASSERT(packet);
     WOLK_ASSERT(packet_size > 2 * FIRMWARE_UPDATE_HASH_SIZE);
 
+    WOLK_UNUSED(packet_size);
+
     return packet;
 }
 
@@ -72,6 +74,8 @@ uint8_t* firmware_update_packet_get_data(uint8_t* packet, size_t packet_size)
     WOLK_ASSERT(packet);
     WOLK_ASSERT(packet_size > 2 * FIRMWARE_UPDATE_HASH_SIZE);
 
+    WOLK_UNUSED(packet_size);
+
     return packet + FIRMWARE_UPDATE_HASH_SIZE;
 }
 
@@ -80,6 +84,8 @@ size_t firmware_update_packet_get_data_size(uint8_t* packet, size_t packet_size)
     /* Sanity check */
     WOLK_ASSERT(packet);
     WOLK_ASSERT(packet_size > 2 * FIRMWARE_UPDATE_HASH_SIZE);
+
+    WOLK_UNUSED(packet);
 
     return packet_size - (2 * FIRMWARE_UPDATE_HASH_SIZE);
 }

--- a/sources/json_parser.c
+++ b/sources/json_parser.c
@@ -177,6 +177,8 @@ static bool json_token_str_equal(const char* json, jsmntok_t* tok, const char* s
 static bool deserialize_actuator_command(char* topic, size_t topic_size, char* buffer, size_t buffer_size,
                                          actuator_command_t* command)
 {
+    WOLK_UNUSED(topic_size);
+
     jsmn_parser parser;
     jsmntok_t tokens[10]; /* No more than 10 JSON token(s) are expected, check
                              jsmn documentation for token definition */
@@ -306,9 +308,9 @@ static char* replace_str(char* str, char* orig, char* rep, int start)
     return replace_str(str, orig, rep, start + p - temp + 2);
 }
 
-bool json_serialize_configuration(const char* device_key, char (*reference)[CONFIGURATION_REFERENCE_SIZE],
-                                  char (*value)[CONFIGURATION_VALUE_SIZE], size_t num_configuration_items,
-                                  outbound_message_t* outbound_message)
+size_t json_serialize_configuration(const char* device_key, char (*reference)[CONFIGURATION_REFERENCE_SIZE],
+                                    char (*value)[CONFIGURATION_VALUE_SIZE], size_t num_configuration_items,
+                                    outbound_message_t* outbound_message)
 {
     outbound_message_init(outbound_message, "", "");
 
@@ -316,7 +318,7 @@ bool json_serialize_configuration(const char* device_key, char (*reference)[CONF
     if (snprintf(outbound_message->topic, WOLK_ARRAY_LENGTH(outbound_message->topic), "configurations/current/%s",
                  device_key)
         >= (int)WOLK_ARRAY_LENGTH(outbound_message->topic)) {
-        return false;
+        return 0;
     }
 
     /* Serialize payload */
@@ -325,7 +327,7 @@ bool json_serialize_configuration(const char* device_key, char (*reference)[CONF
     memset(payload, '\0', payload_size);
 
     if (snprintf(payload, payload_size, "{\"values\":{") >= (int)payload_size) {
-        return false;
+        return 0;
     }
 
     for (size_t i = 0; i < num_configuration_items; ++i) {
@@ -364,9 +366,9 @@ bool json_serialize_configuration(const char* device_key, char (*reference)[CONF
 
     const size_t num_bytes_to_write = payload_size - strlen(payload);
     if (snprintf(payload + strlen(payload), payload_size - strlen(payload), "}}") >= (int)num_bytes_to_write) {
-        return false;
+        return 0;
     }
-    return true;
+    return 1;
 }
 
 size_t json_deserialize_configuration_command(char* buffer, size_t buffer_size,

--- a/sources/json_parser.h
+++ b/sources/json_parser.h
@@ -43,9 +43,9 @@ size_t json_deserialize_actuator_commands(char* topic, size_t topic_size, char* 
 bool json_serialize_readings_topic(reading_t* first_Reading, size_t num_readings, const char* device_key, char* buffer,
                                    size_t buffer_size);
 
-bool json_serialize_configuration(const char* device_key, char (*reference)[CONFIGURATION_REFERENCE_SIZE],
-                                  char (*value)[CONFIGURATION_VALUE_SIZE], size_t num_configuration_items,
-                                  outbound_message_t* outbound_message);
+size_t json_serialize_configuration(const char* device_key, char (*reference)[CONFIGURATION_REFERENCE_SIZE],
+                                    char (*value)[CONFIGURATION_VALUE_SIZE], size_t num_configuration_items,
+                                    outbound_message_t* outbound_message);
 
 size_t json_deserialize_configuration_command(char* buffer, size_t buffer_size,
                                               configuration_command_t* commands_buffer, size_t commands_buffer_size);

--- a/sources/wolk_connector.h
+++ b/sources/wolk_connector.h
@@ -38,7 +38,7 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 
-enum { WOLK_VERSION_MAJOR = 2, WOLK_VERSION_MINOR = 4, WOLK_VERSION_PATCH = 3 };
+enum { WOLK_VERSION_MAJOR = 2, WOLK_VERSION_MINOR = 4, WOLK_VERSION_PATCH = 4 };
 
 typedef enum { PROTOCOL_JSON_SINGLE = 0 } protocol_t;
 

--- a/sources/wolk_utils.h
+++ b/sources/wolk_utils.h
@@ -28,4 +28,6 @@
 
 #define BOOL_TO_STR(b) ((b) ? "true" : "false")
 
+#define WOLK_CEIL(VARIABLE) ((VARIABLE - (unsigned long)VARIABLE) == 0 ? ((unsigned long)VARIABLE) : ((unsigned long)VARIABLE + 1))
+
 #endif


### PR DESCRIPTION
Supress warnings about unused function arguments
Fix signture of function 'json_serialize_configuration'